### PR TITLE
[EVS-1221] Add support for sined data for ABL stations

### DIFF
--- a/src/main/scala/com/thenewmotion/chargenetwork/ocpp/charger/BosService.scala
+++ b/src/main/scala/com/thenewmotion/chargenetwork/ocpp/charger/BosService.scala
@@ -140,21 +140,17 @@ class ConnectorServiceImpl(protected val service: SyncCentralSystem, connectorId
       measurand = Measurand.EnergyActiveImportRegister,
       phase = None,
       location = Location.Outlet,
-      unit = UnitOfMeasure.Kwh)
+      unit = UnitOfMeasure.Kw)
 
     val signedMeterReading: Value = meterValue.copy(context = ReadingContext.TransactionBegin,
-      format = ValueFormat.SignedData, value = signedMeter)
+      format = ValueFormat.SignedData, value = signedMeterValue)
 
     Meter(ChargerClock.now, List(meterValue, signedMeterReading))
   }
 
-  def signedMeter: String = <values>
-    <value>
-      <signedData
-      format="ALFEN">AP;0;3;ALCV3ABBBISHMA2RYEGAZE3HV5YQBQRQAEHAR2MN;BIHEIWSHAAA2W2V7OYYDCNQAAAFACRC2I4ADGAETI4AAAABAOOJYUAGMXEGV4AIAAEEAB7Y6AAO3EAIAAAAAAABQGQ2UINJZGZATGMJTGQ4DAAAAAAAAAACXAAAABKYAAAAA====;R7KGQ3CEYTZI6AWKPOA42MXJTGBW27EUE2E6X7J77J5WMQXPSOM3E27NMVM2D77DPTMO3YACIPTRI===;
-      </signedData>
-    </value>
-  </values>.toString()
+  def signedMeterValue: String = "AP;0;3;ALCV3ABBBISHMA2RYEGAZE3HV5YQBQRQAEHAR2MN;BIHEIWSHAAA2W2V7OYYDCNQAAAFACRC2I4" +
+    "ADGAETI4AAAABAOOJYUAGMXEGV4AIAAEEAB7Y6AAO3EAIAAAAAAABQGQ2UINJZGZATGMJTGQ4DAAAAAAAAAACXAAAABKYAAAAA====;R7KGQ3CEY" +
+    "TZI6AWKPOA42MXJTGBW27EUE2E6X7J77J5WMQXPSOM3E27NMVM2D77DPTMO3YACIPTRI===;"
 
   def stopSession(card: Option[String], transactionId: Int, meterValue: Int, stopReason: StopReason = StopReason.default): Boolean =
     service(StopTransactionReq(transactionId, card, ChargerClock.now, meterValue, stopReason, Nil))

--- a/src/main/scala/com/thenewmotion/chargenetwork/ocpp/charger/BosService.scala
+++ b/src/main/scala/com/thenewmotion/chargenetwork/ocpp/charger/BosService.scala
@@ -140,7 +140,7 @@ class ConnectorServiceImpl(protected val service: SyncCentralSystem, connectorId
       measurand = Measurand.EnergyActiveImportRegister,
       phase = None,
       location = Location.Outlet,
-      unit = UnitOfMeasure.Kw)
+      unit = UnitOfMeasure.Wh)
 
     val signedMeterReading: Value = meterValue.copy(context = ReadingContext.TransactionBegin,
       format = ValueFormat.SignedData, value = signedMeterValue)

--- a/src/main/scala/com/thenewmotion/chargenetwork/ocpp/charger/ChargerConfig.scala
+++ b/src/main/scala/com/thenewmotion/chargenetwork/ocpp/charger/ChargerConfig.scala
@@ -7,6 +7,9 @@ object ChargerConfig {
 }
 
 class ChargerConfig(args: Seq[String]) extends ScallopConf(args) {
+  val AblVendor = "ABL"
+  val EichrechtIdentifier = "EICHRECHT"
+
   val chargerId = opt[String]("id", descr = "Charge point ID of emulated charge point", default = Some("00055103978E"))
   val numberOfConnectors = opt[Int]("connectors", descr = "Number of connectors of emulated charge point", default = Some(2))
   val vendor = opt[String]("vendor", descr = "Charge point vendor", default = Some("The New Motion"))
@@ -27,29 +30,29 @@ class ChargerConfig(args: Seq[String]) extends ScallopConf(args) {
   val reconnectAfter = opt[Int]("reconnect", descr = "Reconnect after <arg> seconds in case of disconnect (JSON). 0 means no reconnect", default = Some(60))
 
 
-  val simulateUser = toggle("user-simulation", descrYes = "Simulate user activity", descrNo = "Don't simulate user activity",  default = Some(false))
-  val simulateFailure = toggle("failure-simulation", descrYes = "Simulate charger failure", descrNo = "Don't simulate charger failure",  default = Some(false))
+  val simulateUser = toggle("user-simulation", descrYes = "Simulate user activity", descrNo = "Don't simulate user activity", default = Some(false))
+  val simulateFailure = toggle("failure-simulation", descrYes = "Simulate charger failure", descrNo = "Don't simulate charger failure", default = Some(false))
 
   val authPassword = opt[String]("auth-password", descr = "set basic auth password", default = None)
   val keystoreFile = opt[String]("keystore-file", descr = "keystore file for ssl", default = None)
   val keystorePassword = opt[String]("keystore-password", descr = "keystore password", default = Some(""))
   val chargeServerUrl = trailArg[String](descr = "Charge server URL base (without trailing slash)", default = Some("http://127.0.0.1:8080/ocppws"))
 
-  validate (listenPort) {
+  validate(listenPort) {
     p => validatePort(p)
   }
 
-  validate (listenApiPort) {
+  validate(listenApiPort) {
     p => validatePort(p)
   }
 
-  validate (connectorPower) {
+  validate(connectorPower) {
     p =>
       if (p >= 3.7 && p <= 22) Right(Unit)
       else Left("Invalid connector power: " + p)
   }
 
-  validate (reconnectAfter) {
+  validate(reconnectAfter) {
     p =>
       if (p >= 0) Right(Unit)
       else Left("Invalid reconnect timeout: " + p)
@@ -60,4 +63,8 @@ class ChargerConfig(args: Seq[String]) extends ScallopConf(args) {
     else Left("Wrong port number: " + p)
 
   verify()
+
+  def isAblVendor: Boolean = vendor.getOrElse("").toUpperCase() == AblVendor
+
+  def isEichrechtCharger: Boolean = chargerId.getOrElse("").toUpperCase().contains(EichrechtIdentifier)
 }


### PR DESCRIPTION
Supports eichrecht signed data for ABL stations. 

**Command to execute the simulator with ABL support:** 

`sbt "run --id EICHRECHT-P1739086 --connectors 1 --protocol-version 1.6 --vendor abl ws://api.local.everon.io/ocpp" `

_Make sure vendor is explicitly stated on the command and station id contains `eichrecht` on it ._ 

**First meter values sent to occp ws when transaction starts:**

```
"Incoming request: [2,"7","MeterValues",{"connectorId":1,"transactionId":2,"meterValue":[{"timestamp":"2020-06-11T08:50:09.940775Z","sampledValue":[{"value":"1000","context":"Transaction.Begin","unit":"kW"},{"value":"AP;0;3;ALCV3ABBBISHMA2RYEGAZE3HV5YQBQRQAEHAR2MN;BIHEIWSHAAA2W2V7OYYDCNQAAAFACRC2I4ADGAETI4AAAABAOOJYUAGMXEGV4AIAAEEAB7Y6AAO3EAIAAAAAAABQGQ2UINJZGZATGMJTGQ4DAAAAAAAAAACXAAAABKYAAAAA====;R7KGQ3CEYTZI6AWKPOA42MXJTGBW27EUE2E6X7J77J5WMQXPSOM3E27NMVM2D77DPTMO3YACIPTRI===;","context":"Transaction.Begin","format":"SignedData","unit":"kW"}]}]}]" 
```
**Following meter values sent with periodic sample:**

```
Incoming request: [2,"9","MeterValues",{"connectorId":1,"transactionId":2,"meterValue":[{"timestamp":"2020-06-11T08:51:10.919833Z","sampledValue":[{"value":"1180"}]}]}]
```

